### PR TITLE
update: groundwork for 1.13 port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ out
 *.iws
 *.iml
 .idea
+mcmodsrepo
 
 # gradle
 build

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,9 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.0'
-group = 'com.tfar.tagtooltip' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = 'tagtooltip'
+version = "${mod_version}"
+group = "com.${mod_vendor}.${mod_id}" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+archivesBaseName = "${mod_id}"
 
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
 
@@ -25,7 +25,7 @@ minecraft {
     // stable_#            Stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'snapshot', version: '20190612-1.14.2'
+    mappings channel: "${mappings_channel}", version: "${mappings_version}"
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
     
     // accessTransformer = file('build/resources/main/META-INF/accesstransformer.cfg')
@@ -71,7 +71,7 @@ dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.14.2-26.0.21'
+    minecraft "net.minecraftforge:forge:${mc_version}-${forge_version}"
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"
@@ -97,12 +97,12 @@ dependencies {
 jar {
     manifest {
         attributes([
-            "Specification-Title": "examplemod",
-            "Specification-Vendor": "examplemodsareus",
-            "Specification-Version": "1", // We are version 1 of ourselves
+            "Specification-Title": "Tag Tooltip",
+            "Specification-Vendor": "${mod_vendor}",
+            "Specification-Version": "${mod_version}",
             "Implementation-Title": project.name,
             "Implementation-Version": "${version}",
-            "Implementation-Vendor" :"examplemodsareus",
+            "Implementation-Vendor": "${mod_vendor}",
             "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
         ])
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,14 @@
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
+
+# Gradle variables
+mod_id=tagtooltip
+mod_version=1.0.0
+mod_vendor=tfar
+
+mc_version=1.14.2
+forge_version=26.0.21
+
+mappings_channel=snapshot
+mappings_version=20190612-1.14.2

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name="${mod_id}-${mc_version}"

--- a/src/main/java/com/tfar/tagtooltip/TagTooltip.java
+++ b/src/main/java/com/tfar/tagtooltip/TagTooltip.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package com.tfar.tagtooltip;
 
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.item.Item;
@@ -22,7 +22,7 @@ public class TagTooltip {
   public static final String MODID = "tagtooltip";
 
   @Mod.EventBusSubscriber(bus=Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
-  public static class TooltipEventt {
+  public static class TooltipEvent {
     @SubscribeEvent
     public static void onTooltip(ItemTooltipEvent e) {
 


### PR DESCRIPTION
**fix:** class name typo TooltipEventt > TooltipEvent
**change:** folder structure now reflect the gradle group
**change:** mod version now has a patch version
**update:** added variables for better build, minecraft version now prefixed in .jar filename

the variables are perfect for the 1.13 port, that way the .jars will be prefixed e.g **tagtooltip-1.14.2-1.0.0.jar** and 1.13.2 for that version, without the version showing up in the mod list, only the mod version shows there.